### PR TITLE
upgrade the checkout version to 4

### DIFF
--- a/.github/workflows/pluto-workflow-shipit.yaml
+++ b/.github/workflows/pluto-workflow-shipit.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download Pluto
         uses: FairwindsOps/pluto/github-action@v5.19.0
       - name: install Kubernetes-deploy(render)


### PR DESCRIPTION
There is a deprecation warning with version 3 for using node16 so the upgrade to version 4 is required

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.


See release note: https://github.com/actions/checkout/releases/tag/v4.0.0