### PR TITLE
upgrade the checkout version to 4 #2

### DIFF
--- a/.github/workflows/pluto-workflow-kustomize.yaml
+++ b/.github/workflows/pluto-workflow-kustomize.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download Pluto
         uses: FairwindsOps/pluto/github-action@v5.19.0
       - name: Install all-in-one Kubernetes tools in a package.


### PR DESCRIPTION
This is same change as [this](https://github.com/scoremedia/devops-github-workflow/pull/7) but left out in the first PR.