### PR TITLE
SRE-3104/upgrade workflow for helm package - casino

### DIFF
--- a/.github/workflows/pluto-workflow-kustomize.yaml
+++ b/.github/workflows/pluto-workflow-kustomize.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           ref: non-prod
           sparse-checkout: values
-        if: ${{ inputs.service_name }} == 'casino'
+        if: ${{ inputs.service_name  == 'casino' }}
       - name: Download Pluto
         uses: FairwindsOps/pluto/github-action@v5.19.0
       - name: Install all-in-one Kubernetes tools in a package.

--- a/.github/workflows/pluto-workflow-kustomize.yaml
+++ b/.github/workflows/pluto-workflow-kustomize.yaml
@@ -28,6 +28,12 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Check out repository code (Casino)
+        uses: actions/checkout@v4
+        with:
+          ref: non-prod
+          sparse-checkout: values
+        if: ${{ inputs.service_name }} == 'casino'
       - name: Download Pluto
         uses: FairwindsOps/pluto/github-action@v5.19.0
       - name: Install all-in-one Kubernetes tools in a package.

--- a/.github/workflows/pluto-workflow-kustomize.yaml
+++ b/.github/workflows/pluto-workflow-kustomize.yaml
@@ -34,11 +34,9 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Check out repository code (Casino)
-        uses: actions/checkout@v4
-        with:
-          ref: non-prod
-          sparse-checkout: values
         if: ${{ inputs.service_name  == 'casino' }}
+        run:
+          git fetch && git checkout origin/non-prod -- values
       - name: Download Pluto
         uses: FairwindsOps/pluto/github-action@v5.19.0
       - name: Install all-in-one Kubernetes tools in a package.


### PR DESCRIPTION
- This is a continuation of [another PR](https://github.com/scoremedia/devops-github-workflow/pull/9)
- This change is targeted for Casino manifest because unlike manifests of other apps such as edgebook, concierge, or web sportsbook where both charts and values files are hosted in single branch(*non-prod*), Casino hosts its chart in *main* branch and its values files in *non-prod* branch.

# Test
- https://github.com/scorebet/casino-manifests/actions/runs/7877271378

<img width="1440" alt="image" src="https://github.com/scoremedia/devops-github-workflow/assets/90635659/9cb7a48b-8149-43f1-a475-e98df7d3c2d3">
