### PR TITLE
Add chart name support

### DIFF
--- a/.github/workflows/pluto-workflow-kustomize.yaml
+++ b/.github/workflows/pluto-workflow-kustomize.yaml
@@ -55,7 +55,7 @@ jobs:
           ## Helm
           else
             # if an user wishes to customize a Helm chart to use
-            CHART_NAME=$([ -n "${{ inputs.chart_name }}" ] && echo "${{ inputs.service_name }}" || echo "${{ inputs.chart_name }}")
+            CHART_NAME=$([ -n "${{ inputs.chart_name }}" ] && echo "${{ inputs.chart_name }}" || echo "${{ inputs.service_name }}")
 
             helm template "charts/$CHART_NAME" --values "${{ inputs.values_base }}" --values "${{ inputs.values_overlay }}" > "$MANIFEST_FILE"
           fi

--- a/.github/workflows/pluto-workflow-kustomize.yaml
+++ b/.github/workflows/pluto-workflow-kustomize.yaml
@@ -21,6 +21,11 @@ on:
         type: string
         default: ""
         description: "(For Helm chart deployment method) Specify a path of overlay values.yaml (or equivalent)"
+      chart_name:
+        required: false
+        type: string
+        default: ""
+        description: "(For Helm chart deployment method) Use this to manually set chart name. For example, corebook is using edgebook chart."
 
 jobs:
   review-k8s-api:
@@ -49,7 +54,10 @@ jobs:
 
           ## Helm
           else
-            helm template "charts/${{ inputs.service_name }}" --values "${{ inputs.values_base }}" --values "${{ inputs.values_overlay }}" > "$MANIFEST_FILE"
+            # if an user wishes to customize a Helm chart to use
+            CHART_NAME=$([ -n "${{ inputs.chart_name }}" ] && echo "${{ inputs.service_name }}" || echo "${{ inputs.chart_name }}")
+
+            helm template "charts/$CHART_NAME" --values "${{ inputs.values_base }}" --values "${{ inputs.values_overlay }}" > "$MANIFEST_FILE"
           fi
 
           pluto detect - --target-versions "k8s=$UNENCRYPTED_TARGET_VERSION" --ignore-deprecations --ignore-removals --output json < "$MANIFEST_FILE" | curl -i -s -X POST "$UNENCRYPTED_OPSLEVEL_PLUTO_INTEGRATION_WEBHOOK_URL?alias=${{ inputs.service_name }}" -H 'content-type: application/json' --data-binary @-


### PR DESCRIPTION
- the workflow originally assumed that a service would use a Helm chart that has same name as the service but there is one exception with Corebook. [Corebook uses Edgebook chart](https://github.com/scorebet/devops-manifests/blob/non-prod/bet-apps/corebook/staging-helm-us.yaml#L42).
- To support Corebook, I included a special input field *chart_name*.