### PR TITLE
[ACC-585] Verify vault secrets workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,27 @@
+name: Run Jest Tests
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Jest tests
+        run: npm test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./.github/workflows/verify-vault-secrets
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -52,7 +52,7 @@ jobs:
         id: vault-keys-output
         shell: bash
         run: |
-          echo '${{ toJson(steps.vault-data.outputs) }}' >> ./${{ matrix.env }}-keys.json
+          echo '${{ toJson(steps.vault-keys.outputs) }}' >> ./${{ matrix.env }}-keys.json
   
   verify-vault-secrets:
     runs-on: non-prod-scorebet-org-runner

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   verify-vault-secrets:
-    runs-on: ubuntu-latest
+    runs-on: runs-on: non-prod-scoremedia-org-runner
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -70,6 +70,11 @@ jobs:
         shell: bash
         run: |
           cd ./shared-actions/.github/workflows/verify-vault-secrets && npm install
+      
+      - name: Debug
+        shell: bash
+        run: |
+          echo ${{ needs.retrieve-vault-secret-keys.outputs.subkeys }}
 
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -65,7 +65,7 @@ jobs:
           cat ./${{ matrix.env }}-${{ matrix.edge }}-${{ matrix.suffix }}-keys.json
 
   verify-vault-secrets:
-    runs-on: non-prod-scorebet-org-runner
+    runs-on: ubuntu-latest
     needs: retrieve-vault-secret-keys
     strategy:
       matrix:
@@ -91,8 +91,8 @@ jobs:
       - name: Download env-edge keys artifacts
         uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.env }}-${{ matrix.edge }}-common-keys
           path: keys
+          pattern: ${{ matrix.env }}-${{ matrix.edge }}-*-keys
       
       - name: Debug
         shell: bash

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -93,12 +93,12 @@ jobs:
         with:
           path: keys
           pattern: ${{ matrix.env }}-${{ matrix.edge }}-*-keys
+          merge-multiple: true
       
       - name: Debug
         shell: bash
         run: |
           ls -R keys
-          cat ./keys/${{ matrix.env }}-${{ matrix.edge }}-common-keys
 
       - name: Extract keys
         id: extract-keys

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -9,9 +9,6 @@ on:
       edges:
         required: true
         type: string
-      vault_token:
-        required: true
-        type: string
       environments:
         required: false
         type: string
@@ -44,6 +41,30 @@ jobs:
         shell: bash
         run: |
           cd ./shared-actions/.github/workflows/verify-vault-secrets && npm install
+      - name: Get Non-Prod Token from Vault
+        id: non-prod-vault-token
+        uses: hashicorp/vault-action@v3
+        with:
+          method: jwt
+          path: github-actions
+          url: https://vault.non-prod.thescore.is
+          role: ${{ inputs.service }}
+          exportToken: true
+          secrets: |
+            thescore/data/infrastructure/github/tokens/scorebet-bot token | GITHUB_PAT ;
+
+      - name: Get Prod Token from Vault
+        id: prod-vault-token
+        uses: hashicorp/vault-action@v3
+        with:
+          method: jwt
+          path: github-actions
+          url: https://vault.prod.thescore.is
+          role: ${{ inputs.service }}
+          exportToken: true
+          secrets: |
+            thescore/data/infrastructure/github/tokens/scorebet-bot token | GITHUB_PAT ;
+
       - uses: actions/github-script@v7
         with:
           script: |
@@ -51,7 +72,8 @@ jobs:
             await script({github, context, core})
           service: ${{ inputs.service }}
           edges: ${{ inputs.edges }}
-          vault_token: ${{ inputs.vault_token }}
+          non_prod_vault_token: ${{ steps.non-prod-vault-token.outputs.GITHUB_PAT }}
+          prod_vault_token: ${{ steps.prod-vault-token.outputs.GITHUB_PAT }}
           environments: ${{ inputs.environments }}
           vault_addr_prod: ${{ inputs.vault_addr_prod }}
           vault_addr_non_prod: ${{ inputs.vault_addr_non_prod }}

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   verify-vault-secrets:
-    runs-on: ubuntu-latest
+    runs-on: non-prod-scorebet-org-runner
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -25,9 +25,7 @@ on:
 jobs:
   verify-vault-secrets:
     runs-on: non-prod-scorebet-org-runner
-    permissions:
-      id-token: write
-      contents: read
+    permissions: write-all
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -98,11 +98,18 @@ jobs:
         shell: bash
         run: |
           ls -R keys
-          cat ./keys/${{ matrix.env }}-${{ matrix.edge }}-common-keys.json
+          cat ./keys/${{ matrix.env }}-${{ matrix.edge }}-common-keys
+
+      - name: Extract keys
+        id: extract-keys
+        shell: bash
+        run: |
+          keys=$(find /path/to/directory -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} +)
+          echo "keys=$keys" >> $GITHUB_OUTPUT
 
       - uses: actions/github-script@v7
         with:
           script: |
             const script = require('./shared-actions/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js')
             await script({github, context, core})
-          keys: ${{fromJson(needs.retrieve-vault-secret-keys.outputs.subkeys)}}
+          keys: ${{fromJson(steps.extract-keys.outputs.keys)}}

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -109,4 +109,4 @@ jobs:
             const script = require('./shared-actions/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js')
             await script({github, context, core})
           keys: ${{ fromJSON(steps.extract-keys.outputs.keys) }}
-          ignoredKeys: ${{ fromJSON(inputs.ignored_keys) }}
+          ignored_keys: ${{ fromJSON(inputs.ignored_keys) }}

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -36,8 +36,6 @@ jobs:
         env: ${{ fromJSON(inputs.environments) }}
         edge: ${{ fromJSON(inputs.edges) }}
         suffix: ${{ fromJSON(inputs.path_suffixes) }}
-    outputs:
-      subkeys: ${{ steps.vault-keys-output.outputs.staging-keys }}
     steps:
       - name: Get Vault Keys
         id: vault-keys
@@ -49,16 +47,20 @@ jobs:
           role: identity
           exportToken: true
           secrets: |
-            scorebet/subkeys/identity/${{ matrix.env }}/us-core/${{ matrix.suffix }} subkeys ;
+            scorebet/subkeys/identity/${{ matrix.env }}/${{ matrix.edge }}/${{ matrix.suffix }} subkeys ;
       - name: Set Output
         id: vault-keys-output
         shell: bash
         run: |
-          echo "${{matrix.env}}-keys=${{steps.vault-keys.outputs.subkeys}}" >> "$GITHUB_OUTPUT"
+          echo '${{ toJson(steps.vault-data.outputs.subkeys) }}' >> ./outputs/${{ matrix.env }}-keys.json
   
   verify-vault-secrets:
     runs-on: non-prod-scorebet-org-runner
     needs: retrieve-vault-secret-keys
+    strategy:
+      matrix:
+        env: ${{ fromJSON(inputs.environments) }}
+        edge : ${{ fromJSON(inputs.edges) }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -79,7 +81,8 @@ jobs:
       - name: Debug
         shell: bash
         run: |
-          echo ${{ needs.retrieve-vault-secret-keys.outputs.subkeys }}
+          ls ./outputs
+          cat ./outputs/${{ matrix.env }}-keys.json
 
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -104,7 +104,7 @@ jobs:
         id: extract-keys
         shell: bash
         run: |
-          keys=$(find /path/to/directory -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} +)
+          keys=$(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} +)
           echo "keys=$keys" >> $GITHUB_OUTPUT
 
       - uses: actions/github-script@v7

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -9,10 +9,13 @@ on:
       edges:
         required: true
         type: string
+      path_suffixes:
+        required: true
+        type: string
       environments:
         required: false
         type: string
-        default: "staging,demo,uat,audit1,ps,production"
+        default: "['staging','demo','uat','audit1','ps','production']"
       vault_addr_prod:
         required: false
         type: string
@@ -23,13 +26,38 @@ on:
         default: "https://vault.non-prod.thescore.is"
 
 jobs:
+  retrieve-vault-secret-keys:
+    runs-on: non-prod-scorebet-org-runner
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      matrix:
+        env: [ ${{ fromJSON(inputs.environments) }} ]
+        edge: [ ${{ fromJSON(inputs.edges) }} ]
+        suffix: [ ${{ fromJSON(inputs.path_suffixes) }} ]
+    outputs:
+      output1: ${{ steps.vault-keys.outputs.subkeys }}
+    steps:
+      - name: Get Vault Keys
+        id: vault-keys
+        uses: hashicorp/vault-action@v3
+        with:
+          method: jwt
+          path: github-actions
+          url: ${{ matrix.env == 'production' && 'https://vault.prod.thescore.is' || 'https://vault.non-prod.thescore.is' }}
+          role: identity
+          exportToken: true
+          secrets: |
+            scorebet/subkeys/identity/${{ matrix.env }}/us-core/${{ matrix.suffix }} subkeys ;
+  
   verify-vault-secrets:
     runs-on: non-prod-scorebet-org-runner
-    permissions: write-all
+    needs: retrieve-vault-secret-keys
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      #- uses: actions/checkout@v4
       - uses: actions/checkout@v4
         with:
           repository: scoremedia/devops-github-workflow
@@ -42,39 +70,10 @@ jobs:
         shell: bash
         run: |
           cd ./shared-actions/.github/workflows/verify-vault-secrets && npm install
-      - name: Get Non-Prod Token from Vault
-        id: non-prod-vault-token
-        uses: hashicorp/vault-action@v3
-        with:
-          method: jwt
-          path: github-actions
-          url: https://vault.non-prod.thescore.is
-          role: ${{ inputs.service }}
-          exportToken: true
-          secrets: |
-            thescore/data/infrastructure/github/tokens/scorebet-bot token | GITHUB_PAT ;
-
-      - name: Get Prod Token from Vault
-        id: prod-vault-token
-        uses: hashicorp/vault-action@v3
-        with:
-          method: jwt
-          path: github-actions
-          url: https://vault.prod.thescore.is
-          role: ${{ inputs.service }}
-          exportToken: true
-          secrets: |
-            thescore/data/infrastructure/github/tokens/scorebet-bot token | GITHUB_PAT ;
 
       - uses: actions/github-script@v7
         with:
           script: |
             const script = require('./shared-actions/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js')
             await script({github, context, core})
-          service: ${{ inputs.service }}
-          edges: ${{ inputs.edges }}
-          non_prod_vault_token: ${{ steps.non-prod-vault-token.outputs.GITHUB_PAT }}
-          prod_vault_token: ${{ steps.prod-vault-token.outputs.GITHUB_PAT }}
-          environments: ${{ inputs.environments }}
-          vault_addr_prod: ${{ inputs.vault_addr_prod }}
-          vault_addr_non_prod: ${{ inputs.vault_addr_non_prod }}
+          keys: ${{fromJson(needs.retrieve-vault-secret-keys.outputs.subkeys)}}

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -96,7 +96,6 @@ jobs:
         id: extract-keys
         shell: bash
         run: |
-          echo $(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} + | tr '\n' ',')
           keys=$(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} + | tr '\n' ',')
           echo "keys='$keys'" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -52,7 +52,7 @@ jobs:
         id: vault-keys-output
         shell: bash
         run: |
-          echo '${{ toJson(steps.vault-data.outputs.subkeys) }}' >> ./outputs/${{ matrix.env }}-keys.json
+          echo '${{ toJson(steps.vault-data.outputs) }}' >> ./${{ matrix.env }}-keys.json
   
   verify-vault-secrets:
     runs-on: non-prod-scorebet-org-runner
@@ -81,8 +81,8 @@ jobs:
       - name: Debug
         shell: bash
         run: |
-          ls ./outputs
-          cat ./outputs/${{ matrix.env }}-keys.json
+          ls
+          cat ${{ matrix.env }}-keys.json
 
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -52,19 +52,25 @@ jobs:
         id: vault-keys-output
         shell: bash
         run: |
-          echo '${{ toJson(steps.vault-keys.outputs.subkeys) }}' >> ./${{ matrix.env }}-keys.json
+          echo '${{ toJson(steps.vault-keys.outputs.subkeys) }}' >> ./${{ matrix.env }}-${{ matrix.edge }}-${{ matrix.suffix }}-keys.json
+      - name: Upload output artifact
+        id: vault-keys-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.env }}-${{ matrix.edge }}-${{ matrix.suffix }}-keys
+          path: ./${{ matrix.env }}-${{ matrix.edge }}-${{ matrix.suffix }}-keys.json
       - name: Debug
         shell: bash
         run: |
-          cat ./${{ matrix.env }}-keys.json
-  
+          cat ./${{ matrix.env }}-${{ matrix.edge }}-${{ matrix.suffix }}-keys.json
+
   verify-vault-secrets:
     runs-on: non-prod-scorebet-org-runner
     needs: retrieve-vault-secret-keys
     strategy:
       matrix:
-        env: ${{ fromJSON(inputs.environments) }}
-        edge : ${{ fromJSON(inputs.edges) }}
+        env: ${{ fromJson(inputs.environments) }}
+        edge : ${{ fromJson(inputs.edges) }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -81,12 +87,18 @@ jobs:
         shell: bash
         run: |
           cd ./shared-actions/.github/workflows/verify-vault-secrets && npm install
+
+      - name: Download env-edge keys artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.env }}-${{ matrix.edge }}-common-keys
+          path: ${{ matrix.env }}-${{ matrix.edge }}-common-keys.json
       
       - name: Debug
         shell: bash
         run: |
           ls
-          cat ${{ matrix.env }}-keys.json
+          cat ${{ matrix.env }}-${{ matrix.edge }}-common-keys.json
 
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -33,11 +33,11 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        env: [ ${{ fromJSON(inputs.environments) }} ]
-        edge: [ ${{ fromJSON(inputs.edges) }} ]
-        suffix: [ ${{ fromJSON(inputs.path_suffixes) }} ]
+        env: ${{ fromJSON(inputs.environments) }}
+        edge: ${{ fromJSON(inputs.edges) }}
+        suffix: ${{ fromJSON(inputs.path_suffixes) }}
     outputs:
-      output1: ${{ steps.vault-keys.outputs.subkeys }}
+      subkeys: ${{ steps.vault-keys.outputs.subkeys }}
     steps:
       - name: Get Vault Keys
         id: vault-keys

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -91,16 +91,12 @@ jobs:
           path: keys
           pattern: ${{ matrix.env }}-${{ matrix.edge }}-*-keys
           merge-multiple: true
-      
-      - name: Debug
-        shell: bash
-        run: |
-          cat ./keys/${{ matrix.env }}-${{ matrix.edge }}-common-keys.json
 
       - name: Extract keys
         id: extract-keys
         shell: bash
         run: |
+          echo $(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} +)
           keys=$(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} +)
           echo "keys=$keys" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -19,7 +19,7 @@ on:
       ignored_keys:
         required: false
         type: string
-        default: "[]"
+        default: ""
       vault_addr_prod:
         required: false
         type: string
@@ -109,4 +109,4 @@ jobs:
             const script = require('./shared-actions/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js')
             await script({github, context, core})
           keys: ${{ fromJSON(steps.extract-keys.outputs.keys) }}
-          ignored_keys: ${{ fromJSON(inputs.ignored_keys) }}
+          ignored_keys: ${{ inputs.ignored_keys }}

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -37,7 +37,7 @@ jobs:
         edge: ${{ fromJSON(inputs.edges) }}
         suffix: ${{ fromJSON(inputs.path_suffixes) }}
     outputs:
-      subkeys: ${{ steps.vault-keys.outputs.subkeys }}
+      subkeys: ${{ steps.vault-keys-output.outputs.staging-keys }}
     steps:
       - name: Get Vault Keys
         id: vault-keys
@@ -50,6 +50,11 @@ jobs:
           exportToken: true
           secrets: |
             scorebet/subkeys/identity/${{ matrix.env }}/us-core/${{ matrix.suffix }} subkeys ;
+      - name: Set Output
+        id: vault-keys-output
+        shell: bash
+        run: |
+          run: echo "${{matrix.env}}-keys=${{steps.vault-keys.outputs.subkeys}}" >> "$GITHUB_OUTPUT"
   
   verify-vault-secrets:
     runs-on: non-prod-scorebet-org-runner

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -54,7 +54,7 @@ jobs:
         id: vault-keys-output
         shell: bash
         run: |
-          run: echo "${{matrix.env}}-keys=${{steps.vault-keys.outputs.subkeys}}" >> "$GITHUB_OUTPUT"
+          echo "${{matrix.env}}-keys=${{steps.vault-keys.outputs.subkeys}}" >> "$GITHUB_OUTPUT"
   
   verify-vault-secrets:
     runs-on: non-prod-scorebet-org-runner

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -49,4 +49,9 @@ jobs:
           script: |
             const script = require('./shared-actions/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js')
             await script({github, context, core})
-          tst: abcdef
+          service: ${{ inputs.service }}
+          edges: ${{ inputs.edges }}
+          vault_token: ${{ inputs.vault_token }}
+          environments: ${{ inputs.environments }}
+          vault_addr_prod: ${{ inputs.vault_addr_prod }}
+          vault_addr_non_prod: ${{ inputs.vault_addr_non_prod }}

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -91,6 +91,11 @@ jobs:
           path: keys
           pattern: ${{ matrix.env }}-${{ matrix.edge }}-*-keys
           merge-multiple: true
+      
+      - name: Debug
+        shell: bash
+        run: |
+          cat ./keys/${{ matrix.env }}-${{ matrix.edge }}-common-keys.json
 
       - name: Extract keys
         id: extract-keys

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -96,9 +96,9 @@ jobs:
         id: extract-keys
         shell: bash
         run: |
-          echo $(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} + | tr ' ' ',')
-          keys=$(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} + | tr ' ' ',')
-          echo "keys=$keys" >> $GITHUB_OUTPUT
+          echo $(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} + | tr '\n' ',')
+          keys=$(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} + | tr '\n' ',')
+          echo "keys='$keys'" >> $GITHUB_OUTPUT
 
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -92,13 +92,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.env }}-${{ matrix.edge }}-common-keys
-          path: ${{ matrix.env }}-${{ matrix.edge }}-common-keys.json
+          path: keys
       
       - name: Debug
         shell: bash
         run: |
-          ls
-          cat ${{ matrix.env }}-${{ matrix.edge }}-common-keys.json
+          ls -R keys
+          cat ./keys/${{ matrix.env }}-${{ matrix.edge }}-common-keys.json
 
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -52,17 +52,13 @@ jobs:
         id: vault-keys-output
         shell: bash
         run: |
-          echo '${{ toJson(steps.vault-keys.outputs.subkeys) }}' >> ./${{ matrix.env }}-${{ matrix.edge }}-${{ matrix.suffix }}-keys.json
+          echo ${{ toJson(steps.vault-keys.outputs.subkeys) }} >> ./${{ matrix.env }}-${{ matrix.edge }}-${{ matrix.suffix }}-keys.json
       - name: Upload output artifact
         id: vault-keys-artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.env }}-${{ matrix.edge }}-${{ matrix.suffix }}-keys
           path: ./${{ matrix.env }}-${{ matrix.edge }}-${{ matrix.suffix }}-keys.json
-      - name: Debug
-        shell: bash
-        run: |
-          cat ./${{ matrix.env }}-${{ matrix.edge }}-${{ matrix.suffix }}-keys.json
 
   verify-vault-secrets:
     runs-on: ubuntu-latest
@@ -74,15 +70,16 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      #- uses: actions/checkout@v4
       - uses: actions/checkout@v4
         with:
           repository: scoremedia/devops-github-workflow
           ref: ACC-465-verify-vault-secrets-workflow
           path: shared-actions
+
       - uses: actions/setup-node@v4
         with:
           node-version: 18
+
       - name: npm install
         shell: bash
         run: |
@@ -94,11 +91,6 @@ jobs:
           path: keys
           pattern: ${{ matrix.env }}-${{ matrix.edge }}-*-keys
           merge-multiple: true
-      
-      - name: Debug
-        shell: bash
-        run: |
-          ls -R keys
 
       - name: Extract keys
         id: extract-keys

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -108,5 +108,5 @@ jobs:
           script: |
             const script = require('./shared-actions/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js')
             await script({github, context, core})
-          keys: ${{fromJson(steps.extract-keys.outputs.keys)}}
-          ignoredKeys: ${{fromJson(inputs.ignored_keys)}}
+          keys: ${{ fromJSON(steps.extract-keys.outputs.keys) }}
+          ignoredKeys: ${{ fromJSON(inputs.ignored_keys) }}

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -25,6 +25,9 @@ on:
 jobs:
   verify-vault-secrets:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -47,7 +47,7 @@ jobs:
           role: identity
           exportToken: true
           secrets: |
-            scorebet/subkeys/identity/${{ matrix.env }}/${{ matrix.edge }} * ;
+            scorebet/subkeys/identity/${{ matrix.env }}/${{ matrix.edge }}/${{ matrix.suffix }} subkeys ;
       - name: Set Output
         id: vault-keys-output
         shell: bash

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         env: ${{ fromJson(inputs.environments) }}
-        edge : ${{ fromJson(inputs.edges) }}
+        edge: ${{ fromJson(inputs.edges) }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -47,12 +47,16 @@ jobs:
           role: identity
           exportToken: true
           secrets: |
-            scorebet/subkeys/identity/${{ matrix.env }}/${{ matrix.edge }}/${{ matrix.suffix }} subkeys ;
+            scorebet/subkeys/identity/${{ matrix.env }}/${{ matrix.edge }} * ;
       - name: Set Output
         id: vault-keys-output
         shell: bash
         run: |
-          echo '${{ toJson(steps.vault-keys.outputs) }}' >> ./${{ matrix.env }}-keys.json
+          echo '${{ toJson(steps.vault-keys.outputs.subkeys) }}' >> ./${{ matrix.env }}-keys.json
+      - name: Debug
+        shell: bash
+        run: |
+          cat ./${{ matrix.env }}-keys.json
   
   verify-vault-secrets:
     runs-on: non-prod-scorebet-org-runner

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -88,7 +88,7 @@ jobs:
           keys=$(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} + | tr '\n' ',')
           echo "keys='$keys'" >> $GITHUB_OUTPUT
 
-            - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: scoremedia/devops-github-workflow
           ref: ACC-465-verify-vault-secrets-workflow

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: scoremedia/devops-github-workflow
-          ref: ACC-465-verify-vault-secrets-workflow
+          ref: master
           path: shared-actions
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -28,6 +28,8 @@ on:
 jobs:
   verify-vault-secrets:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: "['staging','demo','uat','audit1','ps','production']"
+      ignored_keys:
+        required: false
+        type: string
+        default: "[]"
       vault_addr_prod:
         required: false
         type: string
@@ -105,3 +109,4 @@ jobs:
             const script = require('./shared-actions/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js')
             await script({github, context, core})
           keys: ${{fromJson(steps.extract-keys.outputs.keys)}}
+          ignoredKeys: ${{fromJson(inputs.ignored_keys)}}

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -96,8 +96,8 @@ jobs:
         id: extract-keys
         shell: bash
         run: |
-          echo $(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} +)
-          keys=$(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} +)
+          echo $(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} + | tr ' ' ',')
+          keys=$(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} + | tr ' ' ',')
           echo "keys=$keys" >> $GITHUB_OUTPUT
 
       - uses: actions/github-script@v7

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   verify-vault-secrets:
-    runs-on: runs-on: non-prod-scoremedia-org-runner
+    runs-on: non-prod-scoremedia-org-runner
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -74,21 +74,6 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: scoremedia/devops-github-workflow
-          ref: ACC-465-verify-vault-secrets-workflow
-          path: shared-actions
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-
-      - name: npm install
-        shell: bash
-        run: |
-          cd ./shared-actions/.github/workflows/verify-vault-secrets && npm install
-
       - name: Download env-edge keys artifacts
         uses: actions/download-artifact@v4
         with:
@@ -102,6 +87,21 @@ jobs:
         run: |
           keys=$(find ./keys -type f -name "*.json" -exec jq -r 'keys_unsorted[]' {} + | tr '\n' ',')
           echo "keys='$keys'" >> $GITHUB_OUTPUT
+
+            - uses: actions/checkout@v4
+        with:
+          repository: scoremedia/devops-github-workflow
+          ref: ACC-465-verify-vault-secrets-workflow
+          path: shared-actions
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: npm install
+        shell: bash
+        run: |
+          cd ./shared-actions/.github/workflows/verify-vault-secrets && npm install
 
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   verify-vault-secrets:
-    runs-on: non-prod-scoremedia-org-runner
+    runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -49,3 +49,4 @@ jobs:
           script: |
             const script = require('./shared-actions/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js')
             await script({github, context, core})
+          tst: abcdef

--- a/.github/workflows/verify-vault-secrets/package-lock.json
+++ b/.github/workflows/verify-vault-secrets/package-lock.json
@@ -11,7 +11,6 @@
                 "@actions/github": "^6.0.0"
             },
             "devDependencies": {
-                "axios": "^0.24.0",
                 "jest": "^27.0.0"
             }
         },
@@ -49,113 +48,42 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-            "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+            "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.23.4",
-                "chalk": "^2.4.2"
+                "@babel/highlight": "^7.24.2",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "dev": true
-        },
-        "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/@babel/compat-data": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-            "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz",
+            "integrity": "sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.0.tgz",
-            "integrity": "sha512-fQfkg0Gjkza3nf0c7/w6Xf34BW4YvzNfACRLmmb7XRLa6XHdR+K9AlJlxneFfWYf6uhOzuzZVTjF/8KfndZANw==",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.4.tgz",
+            "integrity": "sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.23.5",
-                "@babel/generator": "^7.23.6",
+                "@babel/code-frame": "^7.24.2",
+                "@babel/generator": "^7.24.4",
                 "@babel/helper-compilation-targets": "^7.23.6",
                 "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helpers": "^7.24.0",
-                "@babel/parser": "^7.24.0",
+                "@babel/helpers": "^7.24.4",
+                "@babel/parser": "^7.24.4",
                 "@babel/template": "^7.24.0",
-                "@babel/traverse": "^7.24.0",
+                "@babel/traverse": "^7.24.1",
                 "@babel/types": "^7.24.0",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -178,14 +106,14 @@
             "dev": true
         },
         "node_modules/@babel/generator": {
-            "version": "7.23.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
-            "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
+            "integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.23.6",
-                "@jridgewell/gen-mapping": "^0.3.2",
-                "@jridgewell/trace-mapping": "^0.3.17",
+                "@babel/types": "^7.24.0",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
             },
             "engines": {
@@ -243,12 +171,12 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-            "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+            "version": "7.24.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+            "integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.15"
+                "@babel/types": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -307,9 +235,9 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-            "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+            "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -334,13 +262,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.0.tgz",
-            "integrity": "sha512-ulDZdc0Aj5uLc5nETsa7EPx2L7rM0YJM8r7ck7U73AXi7qOV44IHHRAYZHY6iU1rr3C5N4NtTmMRUJP6kwCWeA==",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.4.tgz",
+            "integrity": "sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.24.0",
-                "@babel/traverse": "^7.24.0",
+                "@babel/traverse": "^7.24.1",
                 "@babel/types": "^7.24.0"
             },
             "engines": {
@@ -348,14 +276,15 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-            "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+            "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.22.20",
                 "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -433,9 +362,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.0.tgz",
-            "integrity": "sha512-QuP/FxEAzMSjXygs8v4N9dvdXzEHN4W1oF3PxuWAtPo08UdM17u89RDMgjLn/mlc56iM0HlLmVkO/wgR+rDgHg==",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
+            "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -592,12 +521,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
-            "integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.1.tgz",
+            "integrity": "sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -621,18 +550,18 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.0.tgz",
-            "integrity": "sha512-HfuJlI8qq3dEDmNU5ChzzpZRWq+oxCZQyMzIMEqLho+AQnhMnKQUzH6ydo3RBl/YjPCuk68Y6s0Gx0AeyULiWw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
+            "integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.23.5",
-                "@babel/generator": "^7.23.6",
+                "@babel/code-frame": "^7.24.1",
+                "@babel/generator": "^7.24.1",
                 "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.24.0",
+                "@babel/parser": "^7.24.1",
                 "@babel/types": "^7.24.0",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
@@ -1033,9 +962,9 @@
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "21.2.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-21.2.0.tgz",
-            "integrity": "sha512-xx+Xd6I7rYvul/hgUDqv6TeGX0IOGnhSg9IOeYgd/uI7IAqUy6DE2B6Ipv2M4mWoxaMcWjIzgTIcv8pMO3F3vw=="
+            "version": "22.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
+            "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q=="
         },
         "node_modules/@octokit/plugin-paginate-rest": {
             "version": "9.2.1",
@@ -1092,13 +1021,13 @@
             }
         },
         "node_modules/@octokit/request": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.3.1.tgz",
-            "integrity": "sha512-fin4cl5eHN5Ybmb/gtn7YZ+ycyUlcyqqkg5lfxeSChqj7sUt6TNaJPehREi+0PABKLREYL8pfaUhH3TicEWNoA==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
+            "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
             "dependencies": {
                 "@octokit/endpoint": "^9.0.1",
                 "@octokit/request-error": "^5.1.0",
-                "@octokit/types": "^13.0.0",
+                "@octokit/types": "^13.1.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
@@ -1119,11 +1048,11 @@
             }
         },
         "node_modules/@octokit/types": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.1.0.tgz",
-            "integrity": "sha512-nBwAFOYqVUUJ2AZFK4ZzESQptaAVqdTDKk8gE0Xr0o99WuPDSrhUC38x0F40xD9OUxXhOOuZKWNNVVLPSHQDvQ==",
+            "version": "13.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
+            "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
             "dependencies": {
-                "@octokit/openapi-types": "^21.0.0"
+                "@octokit/openapi-types": "^22.1.0"
             }
         },
         "node_modules/@sinonjs/commons": {
@@ -1228,9 +1157,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "20.11.24",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
-            "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
+            "version": "20.12.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+            "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -1391,15 +1320,6 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "dev": true
-        },
-        "node_modules/axios": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-            "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-            "dev": true,
-            "dependencies": {
-                "follow-redirects": "^1.14.4"
-            }
         },
         "node_modules/babel-jest": {
             "version": "27.5.1",
@@ -1598,9 +1518,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001594",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001594.tgz",
-            "integrity": "sha512-VblSX6nYqyJVs8DKFMldE2IVCJjZ225LW00ydtUWwh5hk9IfkTOffO6r8gJNsH0qqqeAF8KrbMYA2VEwTlGW5g==",
+            "version": "1.0.30001612",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+            "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
             "dev": true,
             "funding": [
                 {
@@ -1877,9 +1797,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.693",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.693.tgz",
-            "integrity": "sha512-/if4Ueg0GUQlhCrW2ZlXwDAm40ipuKo+OgeHInlL8sbjt+hzISxZK949fZeJaVsheamrzANXvw1zQTvbxTvSHw==",
+            "version": "1.4.750",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.750.tgz",
+            "integrity": "sha512-9ItEpeu15hW5m8jKdriL+BQrgwDTXEL9pn4SkillWFu73ZNNNQ2BKKLS+ZHv2vC9UkNhosAeyfxOf/5OSeTCPA==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -2066,26 +1986,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/follow-redirects": {
-            "version": "1.15.5",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/form-data": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -2213,9 +2113,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
-            "integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
             "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -3431,9 +3331,9 @@
             }
         },
         "node_modules/nwsapi": {
-            "version": "2.2.7",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
-            "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
+            "version": "2.2.9",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.9.tgz",
+            "integrity": "sha512-2f3F0SEEer8bBu0dsNCFF50N0cTThV1nWFYcEYFZttdW0lDAoybv9cQoK7X7/68Z89S7FoRrVjP1LPX4XRf9vg==",
             "dev": true
         },
         "node_modules/once": {

--- a/.github/workflows/verify-vault-secrets/package-lock.json
+++ b/.github/workflows/verify-vault-secrets/package-lock.json
@@ -7,6 +7,9 @@
         "": {
             "name": "verify-vault-secrets",
             "version": "1.0.0",
+            "dependencies": {
+                "@octokit/rest": "^20.1.0"
+            },
             "devDependencies": {
                 "axios": "^0.24.0",
                 "jest": "^27.0.0"
@@ -951,6 +954,175 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@octokit/auth-token": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+            "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+            "dependencies": {
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.1.0",
+                "@octokit/request": "^8.3.1",
+                "@octokit/request-error": "^5.1.0",
+                "@octokit/types": "^13.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
+            "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
+            "dependencies": {
+                "@octokit/types": "^13.1.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
+            "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
+            "dependencies": {
+                "@octokit/request": "^8.3.0",
+                "@octokit/types": "^13.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-21.2.0.tgz",
+            "integrity": "sha512-xx+Xd6I7rYvul/hgUDqv6TeGX0IOGnhSg9IOeYgd/uI7IAqUy6DE2B6Ipv2M4mWoxaMcWjIzgTIcv8pMO3F3vw=="
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz",
+            "integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
+            "dependencies": {
+                "@octokit/types": "^12.6.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+        },
+        "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "dependencies": {
+                "@octokit/openapi-types": "^20.0.0"
+            }
+        },
+        "node_modules/@octokit/plugin-request-log": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+            "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+            "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+            "dependencies": {
+                "@octokit/types": "^12.6.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": "5"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+            "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "dependencies": {
+                "@octokit/openapi-types": "^20.0.0"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.3.1.tgz",
+            "integrity": "sha512-fin4cl5eHN5Ybmb/gtn7YZ+ycyUlcyqqkg5lfxeSChqj7sUt6TNaJPehREi+0PABKLREYL8pfaUhH3TicEWNoA==",
+            "dependencies": {
+                "@octokit/endpoint": "^9.0.1",
+                "@octokit/request-error": "^5.1.0",
+                "@octokit/types": "^13.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
+            "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
+            "dependencies": {
+                "@octokit/types": "^13.1.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/rest": {
+            "version": "20.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.0.tgz",
+            "integrity": "sha512-STVO3itHQLrp80lvcYB2UIKoeil5Ctsgd2s1AM+du3HqZIR35ZH7WE9HLwUOLXH0myA0y3AGNPo8gZtcgIbw0g==",
+            "dependencies": {
+                "@octokit/core": "^5.0.2",
+                "@octokit/plugin-paginate-rest": "^9.1.5",
+                "@octokit/plugin-request-log": "^4.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "^10.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/types": {
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.1.0.tgz",
+            "integrity": "sha512-nBwAFOYqVUUJ2AZFK4ZzESQptaAVqdTDKk8gE0Xr0o99WuPDSrhUC38x0F40xD9OUxXhOOuZKWNNVVLPSHQDvQ==",
+            "dependencies": {
+                "@octokit/openapi-types": "^21.0.0"
+            }
+        },
         "node_modules/@sinonjs/commons": {
             "version": "1.8.6",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
@@ -1324,6 +1496,11 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/before-after-hook": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1650,6 +1827,11 @@
             "engines": {
                 "node": ">=0.4.0"
             }
+        },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
         },
         "node_modules/detect-newline": {
             "version": "3.1.0",
@@ -3255,7 +3437,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -3894,6 +4075,11 @@
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
         },
+        "node_modules/universal-user-agent": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+        },
         "node_modules/universalify": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -4070,8 +4256,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/write-file-atomic": {
             "version": "3.0.3",

--- a/.github/workflows/verify-vault-secrets/package-lock.json
+++ b/.github/workflows/verify-vault-secrets/package-lock.json
@@ -8,11 +8,31 @@
             "name": "verify-vault-secrets",
             "version": "1.0.0",
             "dependencies": {
-                "@octokit/rest": "^20.1.0"
+                "@actions/github": "^6.0.0"
             },
             "devDependencies": {
                 "axios": "^0.24.0",
                 "jest": "^27.0.0"
+            }
+        },
+        "node_modules/@actions/github": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.0.tgz",
+            "integrity": "sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==",
+            "dependencies": {
+                "@actions/http-client": "^2.2.0",
+                "@octokit/core": "^5.0.1",
+                "@octokit/plugin-paginate-rest": "^9.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
+            }
+        },
+        "node_modules/@actions/http-client": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.1.tgz",
+            "integrity": "sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==",
+            "dependencies": {
+                "tunnel": "^0.0.6",
+                "undici": "^5.25.4"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -641,6 +661,14 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1036,17 +1064,6 @@
                 "@octokit/openapi-types": "^20.0.0"
             }
         },
-        "node_modules/@octokit/plugin-request-log": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
-            "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
-            "engines": {
-                "node": ">= 18"
-            },
-            "peerDependencies": {
-                "@octokit/core": "5"
-            }
-        },
         "node_modules/@octokit/plugin-rest-endpoint-methods": {
             "version": "10.4.1",
             "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
@@ -1096,20 +1113,6 @@
                 "@octokit/types": "^13.1.0",
                 "deprecation": "^2.0.0",
                 "once": "^1.4.0"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/@octokit/rest": {
-            "version": "20.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.0.tgz",
-            "integrity": "sha512-STVO3itHQLrp80lvcYB2UIKoeil5Ctsgd2s1AM+du3HqZIR35ZH7WE9HLwUOLXH0myA0y3AGNPo8gZtcgIbw0g==",
-            "dependencies": {
-                "@octokit/core": "^5.0.2",
-                "@octokit/plugin-paginate-rest": "^9.1.5",
-                "@octokit/plugin-request-log": "^4.0.0",
-                "@octokit/plugin-rest-endpoint-methods": "^10.2.0"
             },
             "engines": {
                 "node": ">= 18"
@@ -4039,6 +4042,14 @@
                 "node": ">=8"
             }
         },
+        "node_modules/tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "engines": {
+                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+            }
+        },
         "node_modules/type-detect": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4067,6 +4078,17 @@
             "dev": true,
             "dependencies": {
                 "is-typedarray": "^1.0.0"
+            }
+        },
+        "node_modules/undici": {
+            "version": "5.28.4",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+            "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
             }
         },
         "node_modules/undici-types": {

--- a/.github/workflows/verify-vault-secrets/package-lock.json
+++ b/.github/workflows/verify-vault-secrets/package-lock.json
@@ -7,17 +7,27 @@
         "": {
             "name": "verify-vault-secrets",
             "version": "1.0.0",
-            "dependencies": {
-                "@actions/github": "^6.0.0"
-            },
             "devDependencies": {
+                "@actions/core": "^1.10.1",
+                "@actions/github": "^6.0.0",
                 "jest": "^27.0.0"
+            }
+        },
+        "node_modules/@actions/core": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
+            "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+            "dev": true,
+            "dependencies": {
+                "@actions/http-client": "^2.0.1",
+                "uuid": "^8.3.2"
             }
         },
         "node_modules/@actions/github": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.0.tgz",
             "integrity": "sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==",
+            "dev": true,
             "dependencies": {
                 "@actions/http-client": "^2.2.0",
                 "@octokit/core": "^5.0.1",
@@ -29,6 +39,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.1.tgz",
             "integrity": "sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==",
+            "dev": true,
             "dependencies": {
                 "tunnel": "^0.0.6",
                 "undici": "^5.25.4"
@@ -594,6 +605,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
             "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+            "dev": true,
             "engines": {
                 "node": ">=14"
             }
@@ -915,6 +927,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
             "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "dev": true,
             "engines": {
                 "node": ">= 18"
             }
@@ -923,6 +936,7 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
             "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+            "dev": true,
             "dependencies": {
                 "@octokit/auth-token": "^4.0.0",
                 "@octokit/graphql": "^7.1.0",
@@ -940,6 +954,7 @@
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
             "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
+            "dev": true,
             "dependencies": {
                 "@octokit/types": "^13.1.0",
                 "universal-user-agent": "^6.0.0"
@@ -952,6 +967,7 @@
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
             "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
+            "dev": true,
             "dependencies": {
                 "@octokit/request": "^8.3.0",
                 "@octokit/types": "^13.0.0",
@@ -964,12 +980,14 @@
         "node_modules/@octokit/openapi-types": {
             "version": "22.1.0",
             "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.1.0.tgz",
-            "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q=="
+            "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q==",
+            "dev": true
         },
         "node_modules/@octokit/plugin-paginate-rest": {
             "version": "9.2.1",
             "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz",
             "integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
+            "dev": true,
             "dependencies": {
                 "@octokit/types": "^12.6.0"
             },
@@ -983,12 +1001,14 @@
         "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
             "version": "20.0.0",
             "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+            "dev": true
         },
         "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
             "version": "12.6.0",
             "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
             "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "dev": true,
             "dependencies": {
                 "@octokit/openapi-types": "^20.0.0"
             }
@@ -997,6 +1017,7 @@
             "version": "10.4.1",
             "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
             "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+            "dev": true,
             "dependencies": {
                 "@octokit/types": "^12.6.0"
             },
@@ -1010,12 +1031,14 @@
         "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
             "version": "20.0.0",
             "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+            "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+            "dev": true
         },
         "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
             "version": "12.6.0",
             "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
             "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+            "dev": true,
             "dependencies": {
                 "@octokit/openapi-types": "^20.0.0"
             }
@@ -1024,6 +1047,7 @@
             "version": "8.4.0",
             "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
             "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
+            "dev": true,
             "dependencies": {
                 "@octokit/endpoint": "^9.0.1",
                 "@octokit/request-error": "^5.1.0",
@@ -1038,6 +1062,7 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
             "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
+            "dev": true,
             "dependencies": {
                 "@octokit/types": "^13.1.0",
                 "deprecation": "^2.0.0",
@@ -1051,6 +1076,7 @@
             "version": "13.4.1",
             "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.4.1.tgz",
             "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
+            "dev": true,
             "dependencies": {
                 "@octokit/openapi-types": "^22.1.0"
             }
@@ -1422,7 +1448,8 @@
         "node_modules/before-after-hook": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+            "dev": true
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -1754,7 +1781,8 @@
         "node_modules/deprecation": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+            "dev": true
         },
         "node_modules/detect-newline": {
             "version": "3.1.0",
@@ -3340,6 +3368,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -3946,6 +3975,7 @@
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
             "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
             }
@@ -3984,6 +4014,7 @@
             "version": "5.28.4",
             "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
             "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+            "dev": true,
             "dependencies": {
                 "@fastify/busboy": "^2.0.0"
             },
@@ -4000,7 +4031,8 @@
         "node_modules/universal-user-agent": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+            "dev": true
         },
         "node_modules/universalify": {
             "version": "0.2.0",
@@ -4049,6 +4081,15 @@
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/v8-to-istanbul": {
@@ -4178,7 +4219,8 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true
         },
         "node_modules/write-file-atomic": {
             "version": "3.0.3",

--- a/.github/workflows/verify-vault-secrets/package.json
+++ b/.github/workflows/verify-vault-secrets/package.json
@@ -9,7 +9,6 @@
         "testEnvironment": "node"
     },
     "devDependencies": {
-        "axios": "^0.24.0",
         "jest": "^27.0.0"
     },
     "dependencies": {

--- a/.github/workflows/verify-vault-secrets/package.json
+++ b/.github/workflows/verify-vault-secrets/package.json
@@ -9,9 +9,9 @@
         "testEnvironment": "node"
     },
     "devDependencies": {
+        "@actions/core": "^1.10.1",
+        "@actions/github": "^6.0.0",
         "jest": "^27.0.0"
     },
-    "dependencies": {
-        "@actions/github": "^6.0.0"
-    }
+    "dependencies": {}
 }

--- a/.github/workflows/verify-vault-secrets/package.json
+++ b/.github/workflows/verify-vault-secrets/package.json
@@ -3,14 +3,16 @@
     "version": "1.0.0",
     "description": "GitHub Action to verify secrets exist in Vault",
     "scripts": {
-      "test": "jest"
+        "test": "jest"
     },
     "jest": {
-      "testEnvironment": "node"
+        "testEnvironment": "node"
     },
     "devDependencies": {
-      "jest": "^27.0.0",
-      "axios": "^0.24.0"
+        "axios": "^0.24.0",
+        "jest": "^27.0.0"
+    },
+    "dependencies": {
+        "@octokit/rest": "^20.1.0"
     }
-  }
-  
+}

--- a/.github/workflows/verify-vault-secrets/package.json
+++ b/.github/workflows/verify-vault-secrets/package.json
@@ -13,6 +13,6 @@
         "jest": "^27.0.0"
     },
     "dependencies": {
-        "@octokit/rest": "^20.1.0"
+        "@actions/github": "^6.0.0"
     }
 }

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -18,8 +18,8 @@ module.exports = async ({ github, context, core }) => {
   const envVarsRegex = /System\.fetch_env!\("([^"]+)"\)/g;
 
   const extractEnvVars = (runtimeContent) => {
+    console.log(runtimeContent);
     const matches = runtimeContent.matchAll(envVarsRegex);
-    console.log(matches);
     return Array.from(matches, (match) => match[1]);
   };
 

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -1,13 +1,19 @@
 const axios = require('axios');
 
 module.exports = async ({ github, context, core }) => {
-  console.log(github)
   const vault_token = core.getInput('vault_token');
   const service = core.getInput('service');
   const edges = core.getInput('edges');
   const environments = core.getInput('environments');
   const vault_addr_prod = core.getInput('vault_addr_prod');
   const vault_addr_non_prod = core.getInput('vault_addr_non_prod');
+
+  console.log('token', vault_token);
+  console.log('service', service);
+  console.log('edges', edges);
+  console.log('environments', environments);
+  console.log('vault_addr_prod', vault_addr_prod);
+  console.log('vault_addr_non_prod', vault_addr_non_prod);
 
   const envVarsRegex = /System\.fetch_env!\("([^"]+)"\)/g;
 
@@ -52,19 +58,17 @@ module.exports = async ({ github, context, core }) => {
 
   let envVars = [];
   for (const file of prFiles.data) {
-    console.log(`file name: ${file.filename}`);
     if (file.status !== 'removed') {
-      console.log(`file updated: ${file.filename}`);
       const fileContent = await github.rest.repos.getContent({
         owner: context.repo.owner,
         repo: context.repo.repo,
         path: file.filename,
         ref: context.payload.pull_request.head.sha,
       });
+
       const fileData = Buffer.from(fileContent.data.content, 'base64').toString();
       const fileEnvVars = extractEnvVars(fileData);
 
-      console.log(`file env vars: ${fileEnvVars}`)
       envVars = envVars.concat(fileEnvVars);
     }
   }

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -20,6 +20,7 @@ module.exports = async ({ github, context, core }) => {
   const extractEnvVars = (runtimeContent) => {
     console.log(runtimeContent);
     const matches = runtimeContent.matchAll(envVarsRegex);
+    console.log('matches', matches);
     return Array.from(matches, (match) => match[1]);
   };
 
@@ -31,7 +32,7 @@ module.exports = async ({ github, context, core }) => {
     return environment === 'production' ? prodVaultToken : nonProdVaultToken;
   };
 
-  const checkVaultSecrets = async (vaultToken, environment, edge, service) => {
+  const checkVaultSecrets = async (environment, edge, service) => {
     const url = `${getVaultAddr(environment)}/v1/scorebet/subkeys/${service}/${environment}/${edge}`;
     
     try {
@@ -81,16 +82,15 @@ module.exports = async ({ github, context, core }) => {
 
   for (const environment of environments.split(',')) {
     console.log(`Processing environment: ${environment}`);
-    const vaultAddr = getVaultAddr(environment);
 
     for (const edge of edges.split(',')) {
       console.log(`Processing edge: ${edge}`)
       try {
-        const response = await checkVaultSecrets(vault_token, environment, edge, service);
+        const response = await checkVaultSecrets(environment, edge, service);
         const missingVars = checkEnvVarsInResponse(envVars, response);
 
         if (missingVars.length > 0) {
-          console.error(`Secrets ${missingVars.join(', ')} not found at ${vaultAddr}/v1/scorebet/subkeys/${service}/${environment}/${edge}`);
+          console.error(`Secrets ${missingVars.join(', ')} not found at ${getVaultAddr(environment)}/v1/scorebet/subkeys/${service}/${environment}/${edge}`);
           missingVar = true;
         }
       } catch (error) {

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -1,7 +1,5 @@
 module.exports = async ({ github, context, core }) => {
-  const retrievedKeys = core.getInput('keys');
-
-  console.log('keys', retrievedKeys);
+  const retrievedVaultKeys = core.getInput('keys');
 
   const envVarsRegex = /System\.fetch_env!\("([^"]+)"\)/g;
 
@@ -32,17 +30,12 @@ module.exports = async ({ github, context, core }) => {
       envVars = envVars.concat(fileEnvVars);
     }
   }
-
-  let missingVar = false;
-  let failureFlag = false;
   
-  envVars.filter((envVar) => !retrievedKeys.includes(envVar));
+  const undefinedEnvVars = envVars.filter((envVar) => !retrievedVaultKeys.includes(envVar));
+  console.log(undefinedEnvVars);
 
-  if (failureFlag) {
-    core.error('Failed to retrieve secrets from Vault for one or more environment or edge');
-    core.setFailed();
-  } else if (missingVar) {
-    core.error('One or more environment variables are missing from Vault');
+  if (undefinedEnvVars.length > 0) {
+    core.error(`Environment variables missing from Vault: ${undefinedEnvVars}`);
     core.setFailed();
   } else {
     console.log('All secrets found.');

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -9,7 +9,7 @@ module.exports = async ({ github, context, core }) => {
   const vault_addr_prod = core.getInput('vault_addr_prod');
   const vault_addr_non_prod = core.getInput('vault_addr_non_prod');
 
-  const envVarsRegex = /System\.fetch_env!\("(\\.|[^"\\])*"\)/g;
+  const envVarsRegex = /System\.fetch_env!\("([^"]+)"\)/g;
 
   const extractEnvVars = (runtimeContent) => {
     const matches = runtimeContent.matchAll(envVarsRegex);

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -32,7 +32,7 @@ module.exports = async ({ github, context, core }) => {
 
   const checkVaultSecrets = async (environment, edge, service) => {
     const url = `${getVaultAddr(environment)}/v1/scorebet/subkeys/${service}/${environment}/${edge}`;
-    
+    console.log(getVaultToken(environment));
     try {
       const response = await axios({
         method: 'get',

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -1,8 +1,8 @@
-const envVarsRegex = /[A-Z0-9_]{2,}/g;
+const envVarsRegex = /System\.(fetch_env!|fetch_env|get_env)\(["']([^"']+)["'](?:,\s*([^)]+))?\)/g;
 
 function extractReferencedEnvVars(fileData, ignoredKeys) {
   const matches = fileData.matchAll(envVarsRegex);
-  const extractedEnvVars = Array.from(matches, (match) => match[1]);
+  const extractedEnvVars = Array.from(matches, (match) => match[2]);
 
   return extractedEnvVars.filter((envVar) => !ignoredKeys.includes(envVar))
 }

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -30,7 +30,7 @@ module.exports = async ({ github, context, core }) => {
       const fileData = Buffer.from(fileContent.data.content, 'base64').toString();
       const fileEnvVars = extractReferencedEnvVars(fileData);
 
-      envVars = envVars.concat(fileEnvVars);
+      referencedEnvVars = referencedEnvVars.concat(fileEnvVars);
     }
   }
   

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -45,7 +45,7 @@ module.exports = async ({ github, context, core }) => {
     return missingVars;
   };
 
-  const prFiles = await octokit.rest.pulls.listFiles({
+  const prFiles = await github.pulls.listFiles({
     owner: context.repo.owner,
     repo: context.repo.repo,
     pull_number: context.payload.pull_request.number,
@@ -56,7 +56,7 @@ module.exports = async ({ github, context, core }) => {
     console.log(`file name: ${file.filename}`);
     if (file.status !== 'removed') {
       console.log(`file updated: ${file.filename}`);
-      const fileContent = await octokit.repos.getContent({
+      const fileContent = await github.repos.getContent({
         owner: context.repo.owner,
         repo: context.repo.repo,
         path: file.filename,

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -1,19 +1,19 @@
 const axios = require('axios');
 
 module.exports = async ({ github, context, core }) => {
-  const vault_token = core.getInput('vault_token');
+  const nonProdVaultToken = core.getInput('non_prod_vault_token');
+  const prodVaultToken = core.getInput('prod_vault_token');
   const service = core.getInput('service');
   const edges = core.getInput('edges');
   const environments = core.getInput('environments');
-  const vault_addr_prod = core.getInput('vault_addr_prod');
-  const vault_addr_non_prod = core.getInput('vault_addr_non_prod');
+  const vaultAddrProd = core.getInput('vault_addr_prod');
+  const vaultAddrNonProd = core.getInput('vault_addr_non_prod');
 
-  console.log('token', vault_token);
   console.log('service', service);
   console.log('edges', edges);
   console.log('environments', environments);
-  console.log('vault_addr_prod', vault_addr_prod);
-  console.log('vault_addr_non_prod', vault_addr_non_prod);
+  console.log('vault_addr_prod', vaultAddrProd);
+  console.log('vault_addr_non_prod', vaultAddrNonProd);
 
   const envVarsRegex = /System\.fetch_env!\("([^"]+)"\)/g;
 
@@ -24,18 +24,21 @@ module.exports = async ({ github, context, core }) => {
   };
 
   const getVaultAddr = (environment) => {
-    return environment === 'production' ? vault_addr_prod : vault_addr_non_prod;
+    return environment === 'production' ? vaultAddrProd : vaultAddrNonProd;
+  };
+
+  const getVaultToken = (environment) => {
+    return environment === 'production' ? prodVaultToken : nonProdVaultToken;
   };
 
   const checkVaultSecrets = async (vaultToken, environment, edge, service) => {
-    const vaultAddr = getVaultAddr(environment);
-    const url = `${vaultAddr}/v1/scorebet/subkeys/${service}/${environment}/${edge}`;
+    const url = `${getVaultAddr(environment)}/v1/scorebet/subkeys/${service}/${environment}/${edge}`;
     
     try {
       const response = await axios({
         method: 'get',
         url,
-        headers: { 'X-Vault-Token': vaultToken },
+        headers: { 'X-Vault-Token': getVaultToken(environment) },
       });
 
       return response.data;

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -33,10 +33,10 @@ module.exports = async ({ github, context, core }) => {
   const checkVaultSecrets = async (environment, edge, service) => {
     const url = `${getVaultAddr(environment)}/v1/scorebet/subkeys/${service}/${environment}/${edge}`;
     console.log(getVaultToken(environment));
-    
-    getVaultToken(environment).forEach(element => {
-      console.log(element);
-    });
+
+    for (var i = 0; i < getVaultToken(environment).length; i++) {
+      console.log(getVaultToken(environment).charAt(i));
+    };
 
     try {
       const response = await axios({

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -33,6 +33,11 @@ module.exports = async ({ github, context, core }) => {
   const checkVaultSecrets = async (environment, edge, service) => {
     const url = `${getVaultAddr(environment)}/v1/scorebet/subkeys/${service}/${environment}/${edge}`;
     console.log(getVaultToken(environment));
+    
+    getVaultToken(environment).forEach(element => {
+      console.log(element);
+    });
+
     try {
       const response = await axios({
         method: 'get',

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -12,9 +12,8 @@ module.exports = async ({ github, context, core }) => {
   const envVarsRegex = /System\.fetch_env!\("(\\.|[^"\\])*"\)/g;
 
   const extractEnvVars = (runtimeContent) => {
-    console.log('runtimeContent: ', runtimeContent);
     const matches = runtimeContent.matchAll(envVarsRegex);
-    console.log('matches: ', matches);
+    console.log(matches);
     return Array.from(matches, (match) => match[1]);
   };
 
@@ -63,8 +62,8 @@ module.exports = async ({ github, context, core }) => {
         ref: context.payload.pull_request.head.sha,
       });
       const fileData = Buffer.from(fileContent.data.content, 'base64').toString();
-      console.log(`file content: ${fileData}`)
       const fileEnvVars = extractEnvVars(fileData);
+
       console.log(`file env vars: ${fileEnvVars}`)
       envVars = envVars.concat(fileEnvVars);
     }

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -45,7 +45,7 @@ module.exports = async ({ github, context, core }) => {
     return missingVars;
   };
 
-  const prFiles = await github.pulls.listFiles({
+  const prFiles = await github.rest.pulls.listFiles({
     owner: context.repo.owner,
     repo: context.repo.repo,
     pull_number: context.payload.pull_request.number,
@@ -56,7 +56,7 @@ module.exports = async ({ github, context, core }) => {
     console.log(`file name: ${file.filename}`);
     if (file.status !== 'removed') {
       console.log(`file updated: ${file.filename}`);
-      const fileContent = await github.repos.getContent({
+      const fileContent = await github.rest.repos.getContent({
         owner: context.repo.owner,
         repo: context.repo.repo,
         path: file.filename,

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -14,8 +14,6 @@ module.exports = async ({ github, context, core }) => {
   console.log('environments', environments);
   console.log('vault_addr_prod', vaultAddrProd);
   console.log('vault_addr_non_prod', vaultAddrNonProd);
-  console.log('non prod token', nonProdVaultToken);
-  console.log('prod token', prodVaultToken);
 
   const envVarsRegex = /System\.fetch_env!\("([^"]+)"\)/g;
 

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -1,7 +1,6 @@
 const axios = require('axios');
 
 module.exports = async ({ github, context, core }) => {
-  const tst = core.getInput('tst');
   const vault_token = core.getInput('vault_token');
   const service = core.getInput('service');
   const edges = core.getInput('edges');
@@ -9,7 +8,6 @@ module.exports = async ({ github, context, core }) => {
   const vault_addr_prod = core.getInput('vault_addr_prod');
   const vault_addr_non_prod = core.getInput('vault_addr_non_prod');
 
-  console.log('tst', tst);
   console.log('token', vault_token);
   console.log('service', service);
   console.log('edges', edges);

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -18,9 +18,7 @@ module.exports = async ({ github, context, core }) => {
   const envVarsRegex = /System\.fetch_env!\("([^"]+)"\)/g;
 
   const extractEnvVars = (runtimeContent) => {
-    console.log(runtimeContent);
     const matches = runtimeContent.matchAll(envVarsRegex);
-    console.log('matches', matches);
     return Array.from(matches, (match) => match[1]);
   };
 
@@ -42,9 +40,11 @@ module.exports = async ({ github, context, core }) => {
         headers: { 'X-Vault-Token': getVaultToken(environment) },
       });
 
+      console.log('response', response)
+
       return response.data;
     } catch (error) {
-      console.error(`Failed to retrieve secrets from ${url}`);
+      console.error(`Failed to retrieve secrets from ${url}. Error: ${error}`);
       throw error;
     }
   };
@@ -72,8 +72,6 @@ module.exports = async ({ github, context, core }) => {
 
       const fileData = Buffer.from(fileContent.data.content, 'base64').toString();
       const fileEnvVars = extractEnvVars(fileData);
-
-      console.log(fileEnvVars);
 
       envVars = envVars.concat(fileEnvVars);
     }

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -9,8 +9,6 @@ module.exports = async ({ github, context, core }) => {
   const vault_addr_prod = core.getInput('vault_addr_prod');
   const vault_addr_non_prod = core.getInput('vault_addr_non_prod');
 
-  const octokit = github.getOctokit(process.env.GITHUB_TOKEN)
-
   const envVarsRegex = /System\.fetch_env!\("(\\.|[^"\\])*"\)/g;
 
   const extractEnvVars = (runtimeContent) => {

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -1,8 +1,7 @@
 const axios = require('axios');
-const { Octokit } = require('@octokit/rest');
-
 
 module.exports = async ({ github, context, core }) => {
+  console.log(github)
   const vault_token = core.getInput('vault_token');
   const service = core.getInput('service');
   const edges = core.getInput('edges');
@@ -10,7 +9,7 @@ module.exports = async ({ github, context, core }) => {
   const vault_addr_prod = core.getInput('vault_addr_prod');
   const vault_addr_non_prod = core.getInput('vault_addr_non_prod');
 
-  const octokit = new Octokit({ auth: `token ${process.env.GITHUB_TOKEN}` });
+  const octokit = github.getOctokit(process.env.GITHUB_TOKEN)
 
   const envVarsRegex = /System\.fetch_env!\("(\\.|[^"\\])*"\)/g;
 
@@ -48,7 +47,7 @@ module.exports = async ({ github, context, core }) => {
     return missingVars;
   };
 
-  const prFiles = await octokit.pulls.listFiles({
+  const prFiles = await octokit.rest.pulls.listFiles({
     owner: context.repo.owner,
     repo: context.repo.repo,
     pull_number: context.payload.pull_request.number,

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -1,6 +1,6 @@
 module.exports = async ({ github, context, core }) => {
   const retrievedVaultKeys = core.getInput('keys');
-  const ignoredKeys =  core.getInput('ignored_keys');
+  const ignoredKeys = core.getInput('ignored_keys').split(',');
 
   const envVarsRegex = /System\.fetch_env!\("([^"]+)"\)/g;
 

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -14,6 +14,8 @@ module.exports = async ({ github, context, core }) => {
   console.log('environments', environments);
   console.log('vault_addr_prod', vaultAddrProd);
   console.log('vault_addr_non_prod', vaultAddrNonProd);
+  console.log('non prod token', nonProdVaultToken);
+  console.log('prod token', prodVaultToken);
 
   const envVarsRegex = /System\.fetch_env!\("([^"]+)"\)/g;
 

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -1,6 +1,6 @@
 module.exports = async ({ github, context, core }) => {
   const retrievedVaultKeys = core.getInput('keys');
-  const ignoredKeys =  core.getInput('ignoredKeys');
+  const ignoredKeys =  core.getInput('ignored_keys');
 
   const envVarsRegex = /System\.fetch_env!\("([^"]+)"\)/g;
 

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -73,6 +73,8 @@ module.exports = async ({ github, context, core }) => {
       const fileData = Buffer.from(fileContent.data.content, 'base64').toString();
       const fileEnvVars = extractEnvVars(fileData);
 
+      console.log(fileEnvVars);
+
       envVars = envVars.concat(fileEnvVars);
     }
   }

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -1,4 +1,4 @@
-const envVarsRegex = /System\.fetch_env!\("([^"]+)"\)/g;
+const envVarsRegex = /[A-Z0-9_]{2,}/g;
 
 function extractReferencedEnvVars(fileData, ignoredKeys) {
   const matches = fileData.matchAll(envVarsRegex);

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -4,14 +4,13 @@ const { Octokit } = require('@octokit/rest');
 
 module.exports = async ({ github, context, core }) => {
   const vault_token = core.getInput('vault_token');
-  const github_token = core.getInput('github_token');
   const service = core.getInput('service');
   const edges = core.getInput('edges');
   const environments = core.getInput('environments');
   const vault_addr_prod = core.getInput('vault_addr_prod');
   const vault_addr_non_prod = core.getInput('vault_addr_non_prod');
 
-  const octokit = new Octokit({ auth: `token ${github_token}` });
+  const octokit = new Octokit({ auth: `token ${process.env.GITHUB_TOKEN}` });
 
   const envVarsRegex = /System\.fetch_env!\("(\\.|[^"\\])*"\)/g;
 

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -1,7 +1,7 @@
 module.exports = async ({ github, context, core }) => {
   const retrievedKeys = core.getInput('keys');
 
-  console.log('keys', keys);
+  console.log('keys', retrievedKeys);
 
   const envVarsRegex = /System\.fetch_env!\("([^"]+)"\)/g;
 

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 
 module.exports = async ({ github, context, core }) => {
+  const tst = core.getInput('tst');
   const vault_token = core.getInput('vault_token');
   const service = core.getInput('service');
   const edges = core.getInput('edges');
@@ -8,6 +9,7 @@ module.exports = async ({ github, context, core }) => {
   const vault_addr_prod = core.getInput('vault_addr_prod');
   const vault_addr_non_prod = core.getInput('vault_addr_non_prod');
 
+  console.log('tst', tst);
   console.log('token', vault_token);
   console.log('service', service);
   console.log('edges', edges);

--- a/.github/workflows/verify-vault-secrets/verifyVaultSecrets.spec.js
+++ b/.github/workflows/verify-vault-secrets/verifyVaultSecrets.spec.js
@@ -4,9 +4,9 @@ const core = require('@actions/core');
 
 describe('extractReferencedEnvVars', () => {
   test('should extract referenced environment variables from file content', () => {
-    const fileContent = 'System.fetch_env!("DATABASE_URL") + System.fetch_env!("API_KEY")';
+    const fileContent = 'System.fetch_env!("DATABASE_URL") + System.fetch_env("API_KEY") + System.get_env("API_KEY_2", "default")';
     const extractedEnvVars = extractReferencedEnvVars(fileContent, []);
-    expect(extractedEnvVars).toEqual(['DATABASE_URL', 'API_KEY']);
+    expect(extractedEnvVars).toEqual(['DATABASE_URL', 'API_KEY', 'API_KEY_2']);
   });
 
   test('should filter out ignored environment variables', () => {


### PR DESCRIPTION
Relevant ticket: https://thescore.atlassian.net/browse/ACC-585

Adding a shared workflow to verify that environment variables referenced in Elixir projects have values defined for all environments and edges in Vault.

The action takes inputs (example):
- service (`identity`)
- edges (`"['us-core']"`)
- path_suffixes (`"['common','kafka-worker','oban']"`)
- environments (`"['staging','demo','uat','audit1','ps','production']"`)
- ignored_keys (`APP_VERSION`)
- vault_addr_prod (`https://vault.prod.thescore.is`)
- vault_add_non_prod (`https://vault.non-prod.thescore.is`)

It will use those inputs to generate a matrix of jobs that pull secret names from Vault and store them as artifacts. Then we check per edge and environment that the retrieved keys include environment variables that are referenced in files changed in the relevant PR.

It uses a JS action to compare the referenced environment variables to the secret names retrieved from Vault. That JS action is tested and added to CI for this repo.
