### PR TITLE
[NO-TICKET] Verify Vault Secrets - continue remaining jobs when one fails

### DIFF
--- a/.github/workflows/verify-vault-secrets.yaml
+++ b/.github/workflows/verify-vault-secrets.yaml
@@ -35,6 +35,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    continue-on-error: true
     strategy:
       matrix:
         env: ${{ fromJSON(inputs.environments) }}
@@ -67,6 +68,7 @@ jobs:
   verify-vault-secrets:
     runs-on: ubuntu-latest
     needs: retrieve-vault-secret-keys
+    continue-on-error: true
     strategy:
       matrix:
         env: ${{ fromJson(inputs.environments) }}


### PR DESCRIPTION
Uses the `continue-on-error` option (https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures) for the matrix jobs in the vault-verify-secrets action. This should make it so we don't cancel remaining matrix jobs when one of them fails.