### PR TITLE
SRE-5048: Fix for Pluto workflow for shipIt

### DIFF
--- a/.github/workflows/pluto-workflow-shipit.yaml
+++ b/.github/workflows/pluto-workflow-shipit.yaml
@@ -22,13 +22,18 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Download Pluto
-        uses: FairwindsOps/pluto/github-action@v5.19.0
-      - name: install Kubernetes-deploy(render)
+        uses: FairwindsOps/pluto/github-action@v5.19.4
+      - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
-      - run: gem install activesupport -v 6.1.6
-      - run: gem install kubernetes-deploy
+          ruby-version: 3.3
+      - name: Gem install prerequisites 
+        run: |
+          gem install activesupport -v 6.1.6
+          gem install ffi -v 1.17.0
+      - name: install Kubernetes-deploy(render)
+        run: |
+          gem install kubernetes-deploy -v 0.31.1
       - name: Run Pluto to scan K8S Manifest and send a report to OpsLevel
         shell: bash
         env:
@@ -37,4 +42,3 @@ jobs:
         run: |
           # image=random_value needed just to render Kubernetes manifests
           kubernetes-render --bindings="image=random_value,cluster=random_cluster_value,environment=${{ inputs.environment }},region=random_value" --template-dir ${{ inputs.template_dir }} | pluto detect - --target-versions k8s=$UNENCRYPTED_TARGET_VERSION --ignore-deprecations --ignore-removals --output json | curl -i -s -X POST $UNENCRYPTED_OPSLEVEL_PLUTO_INTEGRATION_WEBHOOK_URL?alias=${{ inputs.service_name }} -H 'content-type: application/json' --data-binary @-
-


### PR DESCRIPTION
# Feature Details

- Resolve the below workflow error
- cleanup step naming
- version bump ruby version (from v2.7 to v3.3)
- install ffi version 1.17.0 
- pin kubernetes-deploy to version 0.31.1 

### error
```shell
ERROR:  Error installing kubernetes-deploy:
	The last version of ffi (>= 1.15.5) to support your Ruby & RubyGems was 1.17.0. Try installing it with `gem install ffi -v 1.17.0` and then running the current command again
	ffi requires RubyGems version >= 3.3.22. The current RubyGems version is 3.1.6. Try 'gem update --system' to update RubyGems itself.
```