### PR TITLE
SRE-5064/repair broken pipeline

### DIFF
--- a/.github/workflows/pluto-workflow-shipit.yaml
+++ b/.github/workflows/pluto-workflow-shipit.yaml
@@ -29,7 +29,7 @@ jobs:
           ruby-version: 2.7
           rubygems: 3.3.22
       - run: gem install activesupport -v 6.1.6
-      - run: gem install ffi -v 1.17.0
+      # - run: gem install ffi -v 1.17.0
       - run: gem install kubernetes-deploy
       - name: Run Pluto to scan K8S Manifest and send a report to OpsLevel
         shell: bash

--- a/.github/workflows/pluto-workflow-shipit.yaml
+++ b/.github/workflows/pluto-workflow-shipit.yaml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Download Pluto
         uses: FairwindsOps/pluto/github-action@v5.19.0
-      - name: install Kubernetes-deploy(render)
+      - name: install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1.6
+          ruby-version: 2.7
       - run: gem install activesupport -v 6.1.6
       - run: gem install kubernetes-deploy
       - name: Run Pluto to scan K8S Manifest and send a report to OpsLevel

--- a/.github/workflows/pluto-workflow-shipit.yaml
+++ b/.github/workflows/pluto-workflow-shipit.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
+          rubygems: 3.3.22
       - run: gem install activesupport -v 6.1.6
       - run: gem install ffi -v 1.17.0
       - run: gem install kubernetes-deploy

--- a/.github/workflows/pluto-workflow-shipit.yaml
+++ b/.github/workflows/pluto-workflow-shipit.yaml
@@ -29,7 +29,6 @@ jobs:
           ruby-version: 2.7
           rubygems: 3.3.22
       - run: gem install activesupport -v 6.1.6
-      # - run: gem install ffi -v 1.17.0
       - run: gem install kubernetes-deploy
       - name: Run Pluto to scan K8S Manifest and send a report to OpsLevel
         shell: bash

--- a/.github/workflows/pluto-workflow-shipit.yaml
+++ b/.github/workflows/pluto-workflow-shipit.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Download Pluto
-        uses: FairwindsOps/pluto/github-action@v5.19.0
+        uses: FairwindsOps/pluto/github-action@v5.19.4
       - name: install Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/pluto-workflow-shipit.yaml
+++ b/.github/workflows/pluto-workflow-shipit.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: install Kubernetes-deploy(render)
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.1.6
       - run: gem install activesupport -v 6.1.6
       - run: gem install kubernetes-deploy
       - name: Run Pluto to scan K8S Manifest and send a report to OpsLevel

--- a/.github/workflows/pluto-workflow-shipit.yaml
+++ b/.github/workflows/pluto-workflow-shipit.yaml
@@ -28,6 +28,7 @@ jobs:
         with:
           ruby-version: 2.7
       - run: gem install activesupport -v 6.1.6
+      - run: gem install ffi -v 1.17.0
       - run: gem install kubernetes-deploy
       - name: Run Pluto to scan K8S Manifest and send a report to OpsLevel
         shell: bash


### PR DESCRIPTION
Live deployment failed with following error.

```
ERROR:  Error installing kubernetes-deploy:
	The last version of ffi (>= 1.15.5) to support your Ruby & RubyGems was 1.17.0. Try installing it with `gem install ffi -v 1.17.0` and then running the current command again
	ffi requires RubyGems version >= 3.3.22. The current RubyGems version is 3.1.6. Try 'gem update --system' to update RubyGems itself.
```

Doing some digging, I simply needed to bump up rubygems version from default(3.1.6) version to the newer version(3.3.22)