### PR TITLE
SRE-8406: Have Pluto Github workflow grab dependencies from jfrog

### DIFF
--- a/.github/workflows/pluto-workflow-kustomize.yaml
+++ b/.github/workflows/pluto-workflow-kustomize.yaml
@@ -65,6 +65,7 @@ jobs:
             # if an user wishes to customize a Helm chart to use
             CHART_NAME=$([ -n "${{ inputs.chart_name }}" ] && echo "${{ inputs.chart_name }}" || echo "${{ inputs.service_name }}")
 
+            helm dependency build "charts/$CHART_NAME"
             helm template "charts/$CHART_NAME" --values "${{ inputs.values_base }}" --values "${{ inputs.values_overlay }}" > "$MANIFEST_FILE"
           fi
 

--- a/.github/workflows/pluto-workflow-kustomize.yaml
+++ b/.github/workflows/pluto-workflow-kustomize.yaml
@@ -43,7 +43,8 @@ jobs:
           image=us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5
 
           docker pull "$image"
-          docker cp "$(docker create --rm "$image"):/pluto" /usr/local/bin/pluto
+          docker cp "$(docker create --rm "$image"):/pluto" /tmp/pluto
+          sudo mv /tmp/pluto /usr/local/bin/pluto
       - name: Install all-in-one Kubernetes tools in a package.
         uses: yokawasa/action-setup-kube-tools@v0.9.3
         with:

--- a/.github/workflows/pluto-workflow-kustomize.yaml
+++ b/.github/workflows/pluto-workflow-kustomize.yaml
@@ -37,6 +37,10 @@ jobs:
         if: ${{ inputs.service_name  == 'casino' }}
         run:
           git fetch && git checkout origin/non-prod -- values
+      - name: Auth with jfrog for deps
+        uses: scorebet/jfrog-auth-action@0.0.10
+        with:
+          artifact-type: "helm"
       - name: Download Pluto
         uses: FairwindsOps/pluto/github-action@v5.19.0
       - name: Install all-in-one Kubernetes tools in a package.

--- a/.github/workflows/pluto-workflow-kustomize.yaml
+++ b/.github/workflows/pluto-workflow-kustomize.yaml
@@ -37,16 +37,16 @@ jobs:
         if: ${{ inputs.service_name  == 'casino' }}
         run:
           git fetch && git checkout origin/non-prod -- values
-      - name: Auth with jfrog for deps
-        uses: scorebet/jfrog-auth-action@0.0.10
-        with:
-          artifact-type: "helm"
       - name: Download Pluto
         uses: FairwindsOps/pluto/github-action@v5.19.0
       - name: Install all-in-one Kubernetes tools in a package.
         uses: yokawasa/action-setup-kube-tools@v0.9.3
         with:
           kubectl: '1.26.13'
+      - name: Auth with jfrog for deps
+        uses: scorebet/jfrog-auth-action@0.0.10
+        with:
+          artifact-type: "helm"
       - name: Run Pluto to scan K8S Manifest and send a report to OpsLevel
         shell: bash
         env:

--- a/.github/workflows/pluto-workflow-kustomize.yaml
+++ b/.github/workflows/pluto-workflow-kustomize.yaml
@@ -38,7 +38,12 @@ jobs:
         run:
           git fetch && git checkout origin/non-prod -- values
       - name: Download Pluto
-        uses: FairwindsOps/pluto/github-action@v5.19.0
+        shell: bash
+        run: |
+          image=us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5
+
+          docker pull "$image"
+          docker cp "$(docker create --rm "$image"):/pluto" /usr/local/bin/pluto
       - name: Install all-in-one Kubernetes tools in a package.
         uses: yokawasa/action-setup-kube-tools@v0.9.3
         with:

--- a/.github/workflows/pluto-workflow-kustomize.yaml
+++ b/.github/workflows/pluto-workflow-kustomize.yaml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   review-k8s-api:
-    runs-on: ubuntu-latest
+    runs-on: non-prod-scorebet-org-runner
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION
Re: https://thescore.atlassian.net/browse/SRE-8406

During Pluto checks, fetches helm chart dependencies prior to rendering helm template.  This is now required since some helm charts depend on a core SRERE helm chart, stored in our private jfrog repo.  Although jfrog is accessible from the internet, its credentials live in Vault, which is not reachable from the internet.

**Changes:**

- Uses SRERE's handy action to authenticate with jfrog.
- This action requires Vault access.  Since vault is inaccessible from the internet, uses our internal Github runners.
- Unfortunately replaces an upstream action to install Pluto.  This action depends on `podman`, which is not available from our Github Actions self-hosted runners (we use Docker as our container runtime).
- Fetches helm dependencies prior to trying to render a template.

**How do I know this works?**

See the before and after in this workflow run: [link](https://github.com/scorebet/edgebook-manifests/actions/runs/13296354329/job/37129095965).

This run was invoked from [this branch](https://github.com/scorebet/edgebook-manifests/pull/1596) of `scorebet/edgebook-manifests`.  In this branch, I modified just the `edgebook` pluto check workflow invocation to use this pull request branch's version of the workflow.

**Notes for reviewers:**

Github workflows are myserious and interesting.  Review commit by commit to track my journey.